### PR TITLE
Fix/overlay ui shift

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,24 @@
+---
+name: Bug report
+about: Create a report to help us improve
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,16 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+#### What does this PR do? \*
+
+#### How to test it? \*
+
+#### Describe alternatives you've considered, if any. \*
+
+<!--- Optional -->
+
+#### Related to / Depends on \*
+
+<!--- Optional -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Small shift of 1px to the UI elements caused by the Overlay component.
 
 ## [0.2.2] - 2019-07-22
 ### Fixed

--- a/react/Overlay.tsx
+++ b/react/Overlay.tsx
@@ -70,6 +70,7 @@ const Overlay: FunctionComponent<Props> = ({
         style={{
           width: 'auto',
           height: 1,
+          marginTop: -1,
         }}
       >
         {position && (


### PR DESCRIPTION
#### What does this PR do?

Prevents a shift of `1px` to the UI that would be caused by the height of the `Overlay` component.

#### How to test it?

-  Before

Go to <https://storecomponents.myvtex.com> and open the minicart, notice how the minicart shifts a bit.

- After

Notice that it does not happen here: <https://overlay--gympassus.myvtex.com/>
