### PR TITLE
Add center alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Center alignment
+
 ## [0.2.4] - 2019-11-13
 
 ## [0.2.3] - 2019-11-06

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,5 +9,21 @@ It is possible to wrap a React element with [Overlay](https://github.com/vtex-ap
 ```
 <Overlay>
   <div>Hello World!</div>
-</Overlay> 
+</Overlay>
 ```
+
+## Props
+
+| Prop name    | Type                  | Description                                                  | Default value |
+| ------------ | --------------------- | ------------------------------------------------------------ | ------------- |
+| `alignment`  | `HorizontalAlignment` | Horizontal alignment                                         | `left`        |
+| `fullWindow` | `Boolean`             | If true, the overlay will fill the whole window horizontally | -             |
+| `target`     | `HTMLElement`         | Defines the container where the overlay will be created.     | -             |
+
+Here are the possible values of `HorizontalAlignment`
+
+| Enum name | Enum value |
+| --------- | ---------- |
+| left      | 'left'     |
+| center    | 'center'   |
+| right     | 'right'    |

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,16 +14,16 @@ It is possible to wrap a React element with [Overlay](https://github.com/vtex-ap
 
 ## Props
 
-| Prop name    | Type                  | Description                                                  | Default value |
-| ------------ | --------------------- | ------------------------------------------------------------ | ------------- |
-| `alignment`  | `HorizontalAlignment` | Horizontal alignment                                         | `left`        |
-| `fullWindow` | `Boolean`             | If true, the overlay will fill the whole window horizontally | -             |
-| `target`     | `HTMLElement`         | Defines the container where the overlay will be created.     | -             |
+| Prop name    | Type          | Description                                                  | Default value |
+| ------------ | ------------- | ------------------------------------------------------------ | ------------- |
+| `alignment`  | `String`      | Horizontal alignment                                         | `left`        |
+| `fullWindow` | `Boolean`     | If true, the overlay will fill the whole window horizontally | -             |
+| `target`     | `HTMLElement` | Defines the container where the overlay will be created.     | -             |
 
 Here are the possible values of `HorizontalAlignment`
 
-| Enum name | Enum value |
-| --------- | ---------- |
-| left      | 'left'     |
-| center    | 'center'   |
-| right     | 'right'    |
+| Value    | Description         |
+| -------- | ------------------- |
+| 'center' | Align to the center |
+| 'left'   | Align to the left   |
+| 'right'  | Align to the right  |

--- a/react/Overlay.tsx
+++ b/react/Overlay.tsx
@@ -23,26 +23,31 @@ enum HorizontalAlignment {
   center = 'center',
 }
 
-const getXPositionByHorizontalAlignment = (alignment: HorizontalAlignment, bounds: ClientRect | DOMRect) => {
-  switch(alignment) {
-    case('left'):
+const getXPositionByHorizontalAlignment = (
+  alignment: HorizontalAlignment,
+  bounds: ClientRect | DOMRect
+) => {
+  switch (alignment) {
+    case 'left':
       return bounds.left
-    case ('right'):
+    case 'right':
       return bounds.right
-    case ('center'):
+    case 'center':
       return (bounds.right + bounds.left) / 2
     default:
       return bounds.left
   }
 }
 
-const getJustifyTypeByHorizontalAlignment = (alignment: HorizontalAlignment) => {
-  switch(alignment) {
-    case('left'):
+const getJustifyTypeByHorizontalAlignment = (
+  alignment: HorizontalAlignment
+) => {
+  switch (alignment) {
+    case 'left':
       return 'justify-start'
-    case ('right'):
+    case 'right':
       return 'justify-end'
-    case ('center'):
+    case 'center':
       return 'justify-center'
     default:
       return 'justify-start'
@@ -103,9 +108,9 @@ const Overlay: FunctionComponent<Props> = ({
         {position && (
           <Portal target={target}>
             <div
-              className={`flex ${
-                getJustifyTypeByHorizontalAlignment(alignment)
-              }`}
+              className={`flex ${getJustifyTypeByHorizontalAlignment(
+                alignment
+              )}`}
               style={{
                 position: 'absolute',
                 left: position.x,

--- a/react/Overlay.tsx
+++ b/react/Overlay.tsx
@@ -20,6 +20,33 @@ interface Position {
 enum HorizontalAlignment {
   right = 'right',
   left = 'left',
+  center = 'center',
+}
+
+const getXPositionByHorizontalAlignment = (alignment: HorizontalAlignment, bounds: ClientRect | DOMRect) => {
+  switch(alignment) {
+    case('left'):
+      return bounds.left
+    case ('right'):
+      return bounds.right
+    case ('center'):
+      return (bounds.right + bounds.left) / 2
+    default:
+      return bounds.left
+  }
+}
+
+const getJustifyTypeByHorizontalAlignment = (alignment: HorizontalAlignment) => {
+  switch(alignment) {
+    case('left'):
+      return 'justify-start'
+    case ('right'):
+      return 'justify-end'
+    case ('center'):
+      return 'justify-center'
+    default:
+      return 'justify-start'
+  }
 }
 
 const Overlay: FunctionComponent<Props> = ({
@@ -36,7 +63,7 @@ const Overlay: FunctionComponent<Props> = ({
       const bounds = container.current.getBoundingClientRect()
 
       setPosition({
-        x: alignment === HorizontalAlignment.left ? bounds.left : bounds.right,
+        x: getXPositionByHorizontalAlignment(alignment, bounds),
         y: bounds.top,
       })
     }
@@ -77,9 +104,7 @@ const Overlay: FunctionComponent<Props> = ({
           <Portal target={target}>
             <div
               className={`flex ${
-                alignment === HorizontalAlignment.left
-                  ? 'justify-start'
-                  : 'justify-end'
+                getJustifyTypeByHorizontalAlignment(alignment)
               }`}
               style={{
                 position: 'absolute',


### PR DESCRIPTION
#### What does this PR do? \*

Add center alignment.

#### How should this be manually tested?

The autocomplete in the search-bar uses the overlay with `"right"` alignment. I changed it to use the `"center"` alignment.

<img width="389" alt="Captura de Tela 2019-12-17 às 12 47 11" src="https://user-images.githubusercontent.com/40380674/71011481-38685400-20cc-11ea-872c-b300df58e0bd.png">


[workspace](https://centeralignment--biggy.myvtex.com/)
