### PR TITLE
adding width and height properties

### DIFF
--- a/react/components/Portal.tsx
+++ b/react/components/Portal.tsx
@@ -26,6 +26,8 @@ const Portal: FunctionComponent<Props> = ({
     <div
       style={{
         position: 'fixed',
+        width: '100%',
+        height: '100%',
         top: 0,
         left: 0,
         ...(cover


### PR DESCRIPTION
What does this PR do? *
Add css: width and height properties in Portal component

The following error is happening:
go to https://melimeloparis.ro/
Click on the login icon.
You will notice that clicking the login box again is not hiding.
this pull request adjusts it.

does not generate toggle on login component dropdown.
https://github.com/vtex-apps/login/blob/1.x/react/components/LoginComponent.js#L95

How to test it? *
Go to https://dev--unimarcdev.myvtex.com/ ?, click the login icon
It is possible to notice that the toggle is happening.