### PR TITLE
Align vertically even if the `fullWindow` prop is true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+-   Prop for align vertically even if the `fullWindow` prop is true 
+
 ## [0.3.0] - 2019-12-26
 
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@ It is possible to wrap a React element with [Overlay](https://github.com/vtex-ap
 
 | Prop name           | Type          | Description                                                  | Default value |
 | ------------        | ------------- | ------------------------------------------------------------ | ------------- |
-| `verticalAlignment` | `Boolean`     | align vertically even if the `fullWindow` prop is true         | `false`
+| `verticalAlignment` | `Boolean`     | align vertically even if the `fullWindow` prop is true       | `false`       |
 | `alignment`         | `String`      | Horizontal alignment                                         | `left`        |
 | `fullWindow`        | `Boolean`     | If true, the overlay will fill the whole window horizontally | -             |
 | `target`            | `HTMLElement` | Defines the container where the overlay will be created.     | -             |

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@ It is possible to wrap a React element with [Overlay](https://github.com/vtex-ap
 
 | Prop name           | Type          | Description                                                  | Default value |
 | ------------        | ------------- | ------------------------------------------------------------ | ------------- |
-| `verticalAlignment` | `Boolean`     | align vertically even if the Fullwindow prop is true                                               | `false`
+| `verticalAlignment` | `Boolean`     | align vertically even if the Fullwindow prop is true         | `false`
 | `alignment`         | `String`      | Horizontal alignment                                         | `left`        |
 | `fullWindow`        | `Boolean`     | If true, the overlay will fill the whole window horizontally | -             |
 | `target`            | `HTMLElement` | Defines the container where the overlay will be created.     | -             |

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,12 +14,12 @@ It is possible to wrap a React element with [Overlay](https://github.com/vtex-ap
 
 ## Props
 
-| Prop name    | Type          | Description                                                  | Default value |
-| ------------ | ------------- | ------------------------------------------------------------ | ------------- |
-| `alignment`  | `String`      | Horizontal alignment                                         | `left`        |
-| `fullWindow` | `Boolean`     | If true, the overlay will fill the whole window horizontally | -             |
-| `target`     | `HTMLElement` | Defines the container where the overlay will be created.     | -             |
-
+| Prop name           | Type          | Description                                                  | Default value |
+| ------------        | ------------- | ------------------------------------------------------------ | ------------- |
+| `verticalAlignment` | `Boolean`     | align vertically even if the Fullwindow prop is true                                               | `false`
+| `alignment`         | `String`      | Horizontal alignment                                         | `left`        |
+| `fullWindow`        | `Boolean`     | If true, the overlay will fill the whole window horizontally | -             |
+| `target`            | `HTMLElement` | Defines the container where the overlay will be created.     | -             |
 Here are the possible values of `HorizontalAlignment`
 
 | Value    | Description         |

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@ It is possible to wrap a React element with [Overlay](https://github.com/vtex-ap
 
 | Prop name           | Type          | Description                                                  | Default value |
 | ------------        | ------------- | ------------------------------------------------------------ | ------------- |
-| `verticalAlignment` | `Boolean`     | align vertically even if the Fullwindow prop is true         | `false`
+| `verticalAlignment` | `Boolean`     | align vertically even if the `fullWindow` prop is true         | `false`
 | `alignment`         | `String`      | Horizontal alignment                                         | `left`        |
 | `fullWindow`        | `Boolean`     | If true, the overlay will fill the whole window horizontally | -             |
 | `target`            | `HTMLElement` | Defines the container where the overlay will be created.     | -             |

--- a/react/Overlay.tsx
+++ b/react/Overlay.tsx
@@ -134,7 +134,7 @@ const Overlay: FunctionComponent<Props> = ({
     )
   }
 
-  if (fullWindow && verticalAlignment) {
+  if (verticalAlignment) {
     return (
       <div ref={container}>
         {position && (

--- a/react/Overlay.tsx
+++ b/react/Overlay.tsx
@@ -10,6 +10,7 @@ import Portal, { Props as PortalProps } from './components/Portal'
 interface Props extends PortalProps {
   fullWindow: boolean
   alignment: HorizontalAlignment
+  verticalAlignment: boolean
 }
 
 interface Position {
@@ -59,6 +60,7 @@ const Overlay: FunctionComponent<Props> = ({
   fullWindow,
   target,
   alignment = HorizontalAlignment.left,
+  verticalAlignment = false,
 }) => {
   const container = useRef<HTMLDivElement>(null)
   const [position, setPosition] = useState<Position>()
@@ -67,14 +69,19 @@ const Overlay: FunctionComponent<Props> = ({
     if (container.current) {
       const bounds = container.current.getBoundingClientRect()
 
-      setPosition({
-        x: !fullWindow
-          ? getXPositionByHorizontalAlignment(alignment, bounds)
-          : 0,
-        y: bounds.top,
-      })
+      if (!fullWindow) {
+        setPosition({
+          x: getXPositionByHorizontalAlignment(alignment, bounds),
+          y: bounds.top,
+        })
+      } else if (verticalAlignment) {
+        setPosition({
+          x: 0,
+          y: bounds.top,
+        })
+      }
     }
-  }, [alignment, fullWindow])
+  }, [alignment, fullWindow, verticalAlignment])
 
   useEffect(() => {
     updatePosition()
@@ -127,18 +134,26 @@ const Overlay: FunctionComponent<Props> = ({
     )
   }
 
+  if (fullWindow && verticalAlignment) {
+    return (
+      <div ref={container}>
+        {position && (
+          <Portal target={target} cover>
+            <div
+              style={{ position: 'absolute', top: position.y, width: '100vw' }}
+            >
+              {children}
+            </div>
+          </Portal>
+        )}
+      </div>
+    )
+  }
+
   return (
-    <div ref={container}>
-      {position && (
-        <Portal target={target} cover>
-          <div
-            style={{ position: 'absolute', top: position.y, width: '100vw' }}
-          >
-            {children}
-          </div>
-        </Portal>
-      )}
-    </div>
+    <Portal target={target} cover>
+      {children}
+    </Portal>
   )
 }
 

--- a/react/Overlay.tsx
+++ b/react/Overlay.tsx
@@ -60,7 +60,7 @@ const Overlay: FunctionComponent<Props> = ({
   fullWindow,
   target,
   alignment = HorizontalAlignment.left,
-  verticalAlignment = false,
+  verticalAlignment = true,
 }) => {
   const container = useRef<HTMLDivElement>(null)
   const [position, setPosition] = useState<Position>()
@@ -139,9 +139,7 @@ const Overlay: FunctionComponent<Props> = ({
       <div ref={container}>
         {position && (
           <Portal target={target} cover>
-            <div
-              style={{ position: 'absolute', top: position.y, width: '100vw' }}
-            >
+            <div className="absolute w-100" style={{ top: position.y }}>
               {children}
             </div>
           </Portal>

--- a/react/Overlay.tsx
+++ b/react/Overlay.tsx
@@ -64,7 +64,7 @@ const Overlay: FunctionComponent<Props> = ({
   const [position, setPosition] = useState<Position>()
 
   const updatePosition = useCallback(() => {
-    if (!fullWindow && container.current) {
+    if (container.current) {
       const bounds = container.current.getBoundingClientRect()
 
       setPosition({
@@ -72,7 +72,7 @@ const Overlay: FunctionComponent<Props> = ({
         y: bounds.top,
       })
     }
-  }, [alignment, fullWindow])
+  }, [alignment])
 
   useEffect(() => {
     updatePosition()
@@ -126,9 +126,17 @@ const Overlay: FunctionComponent<Props> = ({
   }
 
   return (
-    <Portal target={target} cover>
-      {children}
-    </Portal>
+    <div ref={container}>
+      {position && (
+        <Portal target={target} cover>
+          <div
+            style={{ position: 'absolute', top: position.y, width: '100vw' }}
+          >
+            {children}
+          </div>
+        </Portal>
+      )}
+    </div>
   )
 }
 

--- a/react/Overlay.tsx
+++ b/react/Overlay.tsx
@@ -74,7 +74,7 @@ const Overlay: FunctionComponent<Props> = ({
         y: bounds.top,
       })
     }
-  }, [alignment])
+  }, [alignment, fullWindow])
 
   useEffect(() => {
     updatePosition()

--- a/react/Overlay.tsx
+++ b/react/Overlay.tsx
@@ -60,7 +60,7 @@ const Overlay: FunctionComponent<Props> = ({
   fullWindow,
   target,
   alignment = HorizontalAlignment.left,
-  verticalAlignment = true,
+  verticalAlignment = false,
 }) => {
   const container = useRef<HTMLDivElement>(null)
   const [position, setPosition] = useState<Position>()

--- a/react/Overlay.tsx
+++ b/react/Overlay.tsx
@@ -68,7 +68,9 @@ const Overlay: FunctionComponent<Props> = ({
       const bounds = container.current.getBoundingClientRect()
 
       setPosition({
-        x: getXPositionByHorizontalAlignment(alignment, bounds),
+        x: !fullWindow
+          ? getXPositionByHorizontalAlignment(alignment, bounds)
+          : 0,
         y: bounds.top,
       })
     }


### PR DESCRIPTION
#### What does this PR do? \*

This PR adds a proposal to the `Overlay` component so that even if a` fullWindow` proposal is true, it will still align the content vertically with the `ref` container instead of at the top.

#### How to test it? \*

you can visit: https://autocompletefullwidth--storecomponents.myvtex.com, and searching something you will see that autocomplete is now aligned with search-bar