### PR TITLE
Feature/throttle layout calc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Layout recalculation is throttled and delayed for better performance.
 
 ## [0.3.0] - 2019-12-26
 

--- a/react/Overlay.tsx
+++ b/react/Overlay.tsx
@@ -76,6 +76,9 @@ const Overlay: FunctionComponent<Props> = ({
         y: bounds.top,
       })
     }
+  /** Also, the throttling is set to leading: false (which means that
+   * the function won't be called right away, but only after X ms),
+   * to improve hydration performance */
   }, 200, { leading: false }), [alignment, fullWindow])
 
 

--- a/react/Overlay.tsx
+++ b/react/Overlay.tsx
@@ -64,6 +64,9 @@ const Overlay: FunctionComponent<Props> = ({
   const container = useRef<HTMLDivElement>(null)
   const [position, setPosition] = useState<Position>()
 
+  /** updatePosition is throttled due to the use of getBoundingClientRect,
+   * which triggers a recalculation of the entire page layout, which in
+   * turn can be quite heavy */
   const updatePosition = useCallback(throttle(() => {
     if (!fullWindow && container.current) {
       const bounds = container.current.getBoundingClientRect()

--- a/react/Overlay.tsx
+++ b/react/Overlay.tsx
@@ -6,6 +6,7 @@ import React, {
   useCallback,
 } from 'react'
 import Portal, { Props as PortalProps } from './components/Portal'
+import throttle from 'lodash.throttle'
 
 interface Props extends PortalProps {
   fullWindow: boolean
@@ -63,7 +64,7 @@ const Overlay: FunctionComponent<Props> = ({
   const container = useRef<HTMLDivElement>(null)
   const [position, setPosition] = useState<Position>()
 
-  const updatePosition = useCallback(() => {
+  const updatePosition = useCallback(throttle(() => {
     if (!fullWindow && container.current) {
       const bounds = container.current.getBoundingClientRect()
 
@@ -72,7 +73,8 @@ const Overlay: FunctionComponent<Props> = ({
         y: bounds.top,
       })
     }
-  }, [alignment, fullWindow])
+  }, 200, { leading: false }), [alignment, fullWindow])
+
 
   useEffect(() => {
     updatePosition()

--- a/react/package.json
+++ b/react/package.json
@@ -1,9 +1,11 @@
 {
   "dependencies": {
+    "lodash.throttle": "^4.1.1",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"
   },
   "devDependencies": {
+    "@types/lodash.throttle": "^4.1.6",
     "@types/react": "^16.8.15",
     "@types/react-dom": "^16.8.4",
     "@vtex/test-tools": "^0.1.4"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -917,6 +917,18 @@
   dependencies:
     "@types/jest-diff" "*"
 
+"@types/lodash.throttle@^4.1.6":
+  version "4.1.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.throttle/-/lodash.throttle-4.1.6.tgz#f5ba2c22244ee42ff6c2c49e614401a870c1009c"
+  integrity sha512-/UIH96i/sIRYGC60NoY72jGkCJtFN5KVPhEMMMTjol65effe1gPn0tycJqV5tlSwMTzX8FqzB5yAj0rfGHTPNg==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.159"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.159.tgz#61089719dc6fdd9c5cb46efc827f2571d1517065"
+  integrity sha512-gF7A72f7WQN33DpqOWw9geApQPh4M3PxluMtaHxWHXEGSN12/WbcEk/eNSqWNQcQhF66VSZ06vCF94CrHwXJDg==
+
 "@types/node@*", "@types/node@^11.11.1":
   version "11.11.3"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-11.11.3.tgz#7c6b0f8eaf16ae530795de2ad1b85d34bf2f5c58"
@@ -3009,6 +3021,11 @@ lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
+
+lodash.throttle@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
+  integrity sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=
 
 lodash@^4.17.10, lodash@^4.17.11:
   version "4.17.11"


### PR DESCRIPTION
#### What does this PR do? \*
Throttles and delays layout recalculation for better performance.

The re-layouting will be done eventually, but breaking it out from the `hydration` process reduces blocking time (i.e. tasks that take too long)

Important: This only works properly if there are no components that trigger layout recalculation.
This is because once there's a single call to functions like getBoundingClientRect(), the layout of the entire page needs to be calculated.
(Companion PR: https://github.com/vtex-apps/slider/pull/44)

Before:
<img width="240" alt="Screen Shot 2020-08-14 at 18 29 51" src="https://user-images.githubusercontent.com/5691711/90294639-476ef400-de5d-11ea-8942-0591c2ecbb38.png">

(causes this down below 👇 )
<img width="340" alt="Screen Shot 2020-08-14 at 18 39 19" src="https://user-images.githubusercontent.com/5691711/90294720-7e450a00-de5d-11ea-9140-ef05d727d5f2.png">

After:
<img width="181" alt="Screen Shot 2020-08-14 at 18 29 56" src="https://user-images.githubusercontent.com/5691711/90294737-8604ae80-de5d-11ea-9ed3-d6ee0c0cd90e.png">



#### How to test it? \*

https://lbebber3--alssports.myvtex.com/

The search bar uses this component--type something in there to see if it's aligned properly.

#### Describe alternatives you've considered, if any. \*

<!--- Optional -->

#### Related to / Depends on \*

<!--- Optional -->
